### PR TITLE
fix: replace iteritems() with items()

### DIFF
--- a/hydra_genetics/utils/units.py
+++ b/hydra_genetics/utils/units.py
@@ -151,7 +151,7 @@ def get_units(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards, type: 
         files = units.loc[(wildcards.sample, type)].dropna()
     if isinstance(files, pandas.Series):
         files = pandas.DataFrame(
-            [[f[1] for f in files.iteritems()], ], columns=[f[0] for f in files.iteritems()]
+            [[f[1] for f in files.items()], ], columns=[f[0] for f in files.items()]
         ).set_index(units.index.names)
     return [file for file in files.itertuples()]
 

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -264,6 +264,15 @@ class TestUnitUtils(unittest.TestCase):
             2
         )
 
+        # small dataframe that produces a pandas.Series in get_units
+        units3 = pandas.DataFrame(
+            dict(
+                sample=["NA12878", "NA12878", "NA13878"],
+                type=["N", "T", "N"],
+            )
+        ).set_index(["sample", "type"], drop=False)
+        self.assertEqual(len(get_units(units3, Wildcards(fromdict={"sample": "NA12878", "type": "N"}))), 1)
+
     def test_get_unit_barcodes(self):
         from hydra_genetics.utils.units import get_unit_barcodes
         self.assertEqual(


### PR DESCRIPTION
The method `pandas.Series.iteritems()` is deprecated from pandas v1.5.0 and removed from v2.0.0. Fixes #201. The added unit test should fail on the current develop branch and pass with this PR.