### PR TITLE
feat: make read regex less stringent

### DIFF
--- a/hydra_genetics/commands/create.py
+++ b/hydra_genetics/commands/create.py
@@ -330,7 +330,7 @@ class CreateInputFiles(object):
                  platform="Illumina",
                  sample_type="T",
                  sample_regex=r"^([A-Za-z0-9-]+)_.*\.fastq.gz",
-                 read_number_regex="_(R[12]{1})_",
+                 read_number_regex="_(R[12]{1})[_.]{1}",
                  adapters="AGATCGGAAGAGCACACGTCTGAACTCCAGTCA,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT",
                  tc=1.0,
                  force=False,


### PR DESCRIPTION
Default fastq file name often have the following format: `_R1_001.fastq.gz`
but after processing many people choose to change it to: `_R1.fastq.gz`

This new regex should handle more fastq files, making the process easier for users

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
