### PR TITLE
fix: revert incorrect path to `mkdocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.11"
 
 mkdocs:
-  configuration: mkdocs.yaml
+  configuration: mkdocs.yml
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Reverts hydra-genetics/hydra-genetics#262

This change was done to the wrong file, PR #263 is the way to do it.