### PR TITLE
fix: handle case one requested number of reads couldn't be selected

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,6 @@ jobs:
         run: |
           pip install -r requirements.test.txt
       - name: Check pycodestyle
-        run: pycodestyle --max-line-length=130 --statistics ./
+        run: pycodestyle --max-line-length=140 --statistics ./
       - name: run pytest
         run: python -m pytest

--- a/hydra_genetics/commands/create.py
+++ b/hydra_genetics/commands/create.py
@@ -682,5 +682,5 @@ def extract_run_information(file_path, default_barcode=None, number_of_reads=200
             if last_lane != lane:
                 logging.warning("First read and last read have different lane numbers {} vs {}, lane will be set to 0!".
                                 format(last_lane, lane))
-            return (last_machine_id, last_flowcell_id, "0", create_barcode(data, length, number_of_reads, warning_threshold))
-        return (machine_id, flowcell_id, lane, create_barcode(data, length, number_of_reads, warning_threshold))
+            return (last_machine_id, last_flowcell_id, "0", create_barcode(data, length, number_of_reads - counter, warning_threshold))
+        return (machine_id, flowcell_id, lane, create_barcode(data, length, number_of_reads - counter, warning_threshold))


### PR DESCRIPTION
the % value of bases gets incorrect when request number of reads can not be selected. This will make sure that we calculate using number of selected reads and not requested number of reads. It will only affect the warnings

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
