### PR TITLE
fix: name and version extraction from name_and_version split

### DIFF
--- a/hydra_genetics/utils/software_versions.py
+++ b/hydra_genetics/utils/software_versions.py
@@ -249,7 +249,9 @@ def add_software_version_to_config(config, workflow, fail_missing_versions=True)
                             raise Exception(f"could not extract software versions from {image_path}, {value}")
                         else:
                             logger.warning(f"could not extract software versions from {image_path}, {value}")
-                            version_found = [name_and_version.split("_"),
+                            name = name_and_version.split("_")[0]
+                            version = name_and_version.split("_")[1:]
+                            version_found = [[name, version],
                                              ('NOTE', 'version extract from image name and not labels')]
                 else:
                     if fail_missing_versions:

--- a/hydra_genetics/utils/software_versions.py
+++ b/hydra_genetics/utils/software_versions.py
@@ -250,7 +250,7 @@ def add_software_version_to_config(config, workflow, fail_missing_versions=True)
                         else:
                             logger.warning(f"could not extract software versions from {image_path}, {value}")
                             name = name_and_version.split("_")[0]
-                            version = name_and_version.split("_")[1:]
+                            version = "_".join(name_and_version.split("_")[1:])
                             version_found = [[name, version],
                                              ('NOTE', 'version extract from image name and not labels')]
                 else:


### PR DESCRIPTION
The use of split on underscore does not currently handle containers where the version can have an underscore present. Example being the vep container:

docker://ensemblorg/ensembl-vep:release_110.1

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
