### PR TITLE
fix: crash if pipeline dir is not a git repo

### DIFF
--- a/hydra_genetics/utils/software_versions.py
+++ b/hydra_genetics/utils/software_versions.py
@@ -66,52 +66,6 @@ def get_container_prefix(workflow):
     return None
 
 
-def get_pipeline_version(workflow):
-    """
-    Will return the pipelines tag name and commit hex.
-
-    Parameters:
-    -----------
-    workflow: object
-        workflow object from snakemake that contain a basedir attribute
-
-    Return
-    ------
-    dict with pipeline version and commit, ex {'pipeline_version': 'v1', 'pipeline_commit': 'achgk2...kacaa'}
-    """
-
-    def _find_root_repo(path):
-        if path is None:
-            return None
-        elif os.path.isdir(str(os.path.join(str(path), ".git"))):
-            return path
-        else:
-            return _find_root_repo(os.path.dirname(path))
-
-    repo_path = _find_root_repo(getattr(workflow, "basedir"))
-
-    # Initialize a Git repo object
-    repo = git.Repo(repo_path)
-
-    # Get the currently checked out commit
-    head_commit = repo.head.commit
-
-    # Iterate through all tags and find the one pointing to the HEAD commit
-    pipeline_version = None
-    for tag in repo.tags:
-        if tag.commit == head_commit:
-            pipeline_version = tag.name
-            break
-    if pipeline_version is None:
-        try:
-            pipeline_version = repo.active_branch
-        except TypeError as e:
-            logger = logging.getLogger(__name__)
-            logger.warning("Unable to get version (from tags) or an active_branch")
-
-    return {"pipeline_version": str(pipeline_version), "pipeline_commit": str(head_commit)}
-
-
 def get_software_version_from_labels(image_path):
     """
     Function used to create a list of software version used in a singularity image,

--- a/hydra_genetics/utils/software_versions.py
+++ b/hydra_genetics/utils/software_versions.py
@@ -351,9 +351,10 @@ def get_pipeline_version(workflow, pipeline_name="pipeline"):
     ------
     dict with pipeline version and commit, ex {'pipeline_name': {'version': 'v1', 'pipeline_commit': 'achgk2...kacaa'}}
     """
+    logger = logging.getLogger(__name__)
 
     def _find_root_repo(path):
-        if path is None:
+        if path is None or os.path.dirname(str(path)) == str(path):
             return None
         elif os.path.isdir(str(os.path.join(str(path), ".git"))):
             return path
@@ -361,6 +362,10 @@ def get_pipeline_version(workflow, pipeline_name="pipeline"):
             return _find_root_repo(os.path.dirname(path))
 
     repo_path = _find_root_repo(getattr(workflow, "basedir"))
+
+    if not repo_path:
+        logger.warning("Pipeline directory is not a git repo")
+        return {pipeline_name: {"version": None, "commit_id": None}}
 
     # Initialize a Git repo object
     repo = git.Repo(repo_path)
@@ -378,7 +383,6 @@ def get_pipeline_version(workflow, pipeline_name="pipeline"):
         try:
             pipeline_version = repo.active_branch
         except TypeError as e:
-            logger = logging.getLogger(__name__)
             logger.warning("Unable to get version (from tags) or an active_branch")
 
     return {pipeline_name: {"version": str(pipeline_version), "commit_id": str(head_commit)}}

--- a/tests/utils/test_pipeline_version.py
+++ b/tests/utils/test_pipeline_version.py
@@ -1,0 +1,46 @@
+import os
+import git
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+from hydra_genetics.utils import software_versions
+
+
+class TestPipelineVersion(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_plain_directory_version(self):
+        # create a mock pipeline, in this case an empty directory
+        pipeline_dir = tempfile.mkdtemp()
+
+        # create a mock workflow
+        workflow = Mock(basedir=pipeline_dir)
+
+        version = software_versions.get_pipeline_version(workflow, "test_pipeline")
+        self.assertEqual(version, {"test_pipeline": {"version": None, "commit_id": None}})
+
+    def test_git_directory_version(self):
+        # create a mock repo with an empty README
+        repo_dir = tempfile.mkdtemp()
+        repo = git.Repo.init(repo_dir, initial_branch="develop")
+        repo_file = os.path.join(repo_dir, "README.md")
+        open(repo_file, "wb").close()
+        repo.index.add([repo_file])
+        commit = repo.index.commit("initial commit")
+
+        # create a mock workflow
+        workflow = Mock(basedir=repo_dir)
+
+        # no tag, so version will be the branch name
+        version = software_versions.get_pipeline_version(workflow, "test_pipeline")
+        self.assertEqual(version, {"test_pipeline": {"version": "develop", "commit_id": commit.hexsha}})
+
+        # create a tag
+        repo.create_tag("v1.2.3")
+        version = software_versions.get_pipeline_version(workflow, "test_pipeline")
+        self.assertEqual(version, {"test_pipeline": {"version": "v1.2.3", "commit_id": commit.hexsha}})


### PR DESCRIPTION
If the pipeline basedir and none of its parents is a git repo, the `_find_root_repo` function would end up in a state of infinite recursion once it reaches the root directory. This PR addresses this by checking for this state, and then returning `None` for the version and the commit hash if the directory is not identified as a git repo.

Also, there were two seemingly identical `get_pipeline_version` functions, apart from the function signature and the structure of the return value. I removed the one that was obscured.