### PR TITLE
fix: Handling of missing multiqc module

### DIFF
--- a/hydra_genetics/pipeline-template/workflow/rules/common.smk
+++ b/hydra_genetics/pipeline-template/workflow/rules/common.smk
@@ -20,10 +20,10 @@ from hydra_genetics.utils.misc import export_config_as_file
 from hydra_genetics.utils.software_versions import add_version_files_to_multiqc
 from hydra_genetics.utils.software_versions import add_software_version_to_config
 from hydra_genetics.utils.software_versions import export_pipeline_version_as_file
-from hydra_genetics.utils.software_versions import export_software_version_as_files
+from hydra_genetics.utils.software_versions import export_software_version_as_file
 from hydra_genetics.utils.software_versions import get_pipeline_version
-from hydra_genetics.utils.software_versions import touch_pipeline_verion_file_name
-from hydra_genetics.utils.software_versions import touch_software_version_files
+from hydra_genetics.utils.software_versions import touch_pipeline_version_file_name
+from hydra_genetics.utils.software_versions import touch_software_version_file
 from hydra_genetics.utils.software_versions import use_container
 
 min_version("{{ min_snakemake_version }}")
@@ -52,9 +52,9 @@ except WorkflowError as we:
 
 date_string = datetime.now().strftime('%Y%m%d--%H-%M-%S')
 pipeline_version = get_pipeline_version(workflow, pipeline_name="{{ short_name }}")
-version_files = touch_pipeline_verion_file_name(pipeline_version, date_string=date_string, directory="results/versions/software")
+version_files = touch_pipeline_version_file_name(pipeline_version, date_string=date_string, directory="results/versions/software")
 if use_container(workflow):
-    version_files += touch_software_version_files(config, date_string=date_string, directory="results/versions/software")
+    version_files += touch_software_version_file(config, date_string=date_string, directory="results/versions/software")
 add_version_files_to_multiqc(config, version_files)
 
 onstart:

--- a/hydra_genetics/utils/software_versions.py
+++ b/hydra_genetics/utils/software_versions.py
@@ -34,8 +34,12 @@ def _create_container_name_version_string(image_information):
 
 
 def add_version_files_to_multiqc(config, file_list):
-    for report in config["multiqc"]["reports"]:
-        config["multiqc"]["reports"][report]["qc_files"] += file_list
+    if "multiqc" in config.keys():
+        for report in config["multiqc"]["reports"]:
+            config["multiqc"]["reports"][report]["qc_files"] += file_list
+    else:
+        logger = logging.getLogger(__name__)
+        logger.warning(f"Could not find key multiqc in configuration.")
 
 
 def _touch(fname):


### PR DESCRIPTION
### This PR:

- When running a simple pipeline as described in https://hydra-genetics.readthedocs.io/en/latest/tutorials/simple_pipeline/ the workflow will fail due to a key error in the config.yaml file. MultiQC is expected to always be included as a module. However, in this simple case this key is missing in the configuration file. This will now be handled and the workflow will not fail if multiqc is missing from the configuration file. Instead a warning will be logged.

- Corrected imports in common.smk to correspond to function names in software_versions.py
