### PR TITLE
fix: handle missing VEP annotation

### DIFF
--- a/hydra_genetics/utils/io/hotspot_report.py
+++ b/hydra_genetics/utils/io/hotspot_report.py
@@ -67,7 +67,6 @@ def generate_hotspot_report(sample,
             transcript = variant.info['CSQ'][0].split("|")[vep_fields['Feature']]
         except KeyError:
             continue
-        
         transcript_dict[variant_key] = transcript
 
     if vcf_file_wo_pick is not None:

--- a/hydra_genetics/utils/io/hotspot_report.py
+++ b/hydra_genetics/utils/io/hotspot_report.py
@@ -63,7 +63,11 @@ def generate_hotspot_report(sample,
             raise Exception("Multiple allele found: " + str(variant.alts))
         chromosomes_to_look_at.add(variant.chrom)
         variant_key = f"{variant.chrom}_{variant.start}_{variant.stop}_{variant.ref}_{','.join(variant.alts)}"
-        transcript = variant.info['CSQ'][0].split("|")[vep_fields['Feature']]
+        try:
+            transcript = variant.info['CSQ'][0].split("|")[vep_fields['Feature']]
+        except KeyError:
+            continue
+        
         transcript_dict[variant_key] = transcript
 
     if vcf_file_wo_pick is not None:

--- a/hydra_genetics/utils/io/utils.py
+++ b/hydra_genetics/utils/io/utils.py
@@ -36,14 +36,20 @@ def get_annotation_data_vep(field_dict, transcript_dict=None):
     def extractor(variant, info_name):
         data = None
         if not transcript_dict:
-            data = variant.info['CSQ'][0].split("|")[field_dict[info_name]]
+            try:
+                data = variant.info['CSQ'][0].split("|")[field_dict[info_name]]
+            except KeyError:
+                return None
         else:
             variant_key = f"{variant.chrom}_{variant.start}_{variant.stop}_{variant.ref}_{','.join(variant.alts)}"
-            for transcript_data in variant.info['CSQ']:
-                if transcript_data.split("|")[field_dict['Feature']].startswith(transcript_dict[variant_key]):
-                    data = transcript_data.split("|")[field_dict[info_name]]
-            if data is None:
-                data = variant.info['CSQ'][0].split("|")[field_dict[info_name]]
+            try:
+                for transcript_data in variant.info['CSQ']:
+                    if transcript_data.split("|")[field_dict['Feature']].startswith(transcript_dict[variant_key]):
+                        data = transcript_data.split("|")[field_dict[info_name]]
+                if data is None:
+                    data = variant.info['CSQ'][0].split("|")[field_dict[info_name]]
+            except KeyError:
+                return None
         if data == "":
             return None
         return data


### PR DESCRIPTION
When VEP > 109 can't annotate a variant it leaves the variant in the vcf file without a CSQ file. Previously the variant was filtered. This PR fixes this and returns None for all filter values. The individual filters NA handling will then determine if the variant should be filtered or not. The default is NA_FALSE which does not filter the variant.

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
