### PR TITLE
test: fix typo in lint.yaml

### DIFF
--- a/hydra_genetics/pipeline-template/.github/workflows/lint.yaml
+++ b/hydra_genetics/pipeline-template/.github/workflows/lint.yaml
@@ -31,4 +31,4 @@ jobs:
       - name: Linting
         working-directory: .tests/integration
         run: |
-          snakemake --lint -n -s ../../workflow/Snakefile --configfiles ../../config/config.yaml config/config.yaml"
+          snakemake --lint -n -s ../../workflow/Snakefile --configfiles ../../config/config.yaml config/config.yaml


### PR DESCRIPTION
a lonely " in the end of the last line, breaks linter

### This PR:

Fixed: lint workflow template

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
