### PR TITLE
feat!: migrate to Python 3.12 and snakemake 9

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,15 +19,17 @@ jobs:
   python_code:
     name: check pycodestyle and unittest
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-      - name: Add conda to system path
-        run: |
-          echo $CONDA/bin >> $GITHUB_PATH
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies tests
         run: |
           pip install -e .

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,11 +20,11 @@ jobs:
     name: check pycodestyle and unittest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.12"
       - name: Add conda to system path
         run: |
           echo $CONDA/bin >> $GITHUB_PATH

--- a/.github/workflows/test-build-mkdocs.yaml
+++ b/.github/workflows/test-build-mkdocs.yaml
@@ -16,11 +16,11 @@ jobs:
     name: build mkdocs
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.12"
       - name: Install requirements.txt
         run: |
           pip install -e .

--- a/.github/workflows/testrun-commands.yaml
+++ b/.github/workflows/testrun-commands.yaml
@@ -17,14 +17,17 @@ on:
 
 jobs:
   python_code:
-    name: run hydra-genetics commands
+    name: run hydra-genetics commands (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Add conda to system path
         run: |
           echo $CONDA/bin >> $GITHUB_PATH

--- a/.github/workflows/testrun-commands.yaml
+++ b/.github/workflows/testrun-commands.yaml
@@ -20,11 +20,11 @@ jobs:
     name: run hydra-genetics commands
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.12"
       - name: Add conda to system path
         run: |
           echo $CONDA/bin >> $GITHUB_PATH

--- a/.github/workflows/testrun-commands.yaml
+++ b/.github/workflows/testrun-commands.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ dist
 venv
 samples.tsv
 units.tsv
-.venv/
+site/
+.venv*/
+venv*/
 .idea/
 .vscode/
 hydra_genetics/_version.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 
 jinja2>=3.1.2
-mkdocs==1.4.2
+mkdocs>=1.5.0
 pymdown-extensions==9.10
 mkdocs-schema-reader==0.11.1
 mkdocs-simple-hooks==0.1.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,9 @@
 
 jinja2>=3.1.2
 mkdocs>=1.5.0
-pymdown-extensions==9.10
+pymdown-extensions==10.21
 mkdocs-schema-reader==0.11.1
 mkdocs-simple-hooks==0.1.5
-mdx_spanner==0.0.5
+mdx_spanner==0.1.0
 mkdocs-yaml-schema-plugin==0.2.3
-mkdocs-snakemake-rule-plugin==0.3.3
-mkdocs-material==9.1.7
+mkdocs-snakemake-rule-plugin==0.4.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ pymdown-extensions==10.21
 mkdocs-schema-reader==0.11.1
 mkdocs-simple-hooks==0.1.5
 mdx_spanner==0.1.0
-mkdocs-yaml-schema-plugin==0.2.3
-mkdocs-snakemake-rule-plugin==0.4.1
+mkdocs-yaml-schema-plugin==0.3.0
+mkdocs-snakemake-rule-plugin==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 
-jinja2<3.1.0
+jinja2>=3.1.2
 mkdocs==1.4.2
 pymdown-extensions==9.10
 mkdocs-schema-reader==0.11.1

--- a/hydra_genetics/utils/misc.py
+++ b/hydra_genetics/utils/misc.py
@@ -71,15 +71,15 @@ def replace_dict_variables(config):
     '''
     def update_dict(temp_config):
         for k in temp_config:
-            if type(temp_config[k]) is dict:
+            if isinstance(temp_config[k], dict):
                 temp_config[k] = update_dict(temp_config[k])
-            elif type(temp_config[k]) is str:
+            elif isinstance(temp_config[k], str):
                 match = re.findall(r'\{\{([A-Za-z0-9_]+)\}\}', temp_config[k])
                 for m in match:
                     temp_config[k] = temp_config[k].replace("{{" + m + "}}", config[m])
-            elif type(temp_config[k]) is list:
+            elif isinstance(temp_config[k], list):
                 for i in range(len(temp_config[k])):
-                    if type(temp_config[k][i]) is str:
+                    if isinstance(temp_config[k][i], str):
                         match = re.findall(r'\{\{([A-Za-z0-9_]+)\}\}', temp_config[k][i])
                         for m in match:
                             temp_config[k][i] = temp_config[k][i].replace("{{" + m + "}}", config[m])
@@ -111,7 +111,7 @@ def get_input_aligned_bam(wildcards, config, *, default_path="alignment/samtools
     path prefixes.
 
     Args:
-        wildcards (snakemake.io.Wildcards): Wildcards object containing sample and type information.
+        wildcards (snakemake.io.container.Wildcards): Wildcards object containing sample and type information.
         config (dict): Configuration dictionary with possible keys:
             - aligner (str or None): The aligner used for generating the BAM file.
         set_type (str or None): Override the type from wildcards. Must be None, 'N', 'T', or 'R'.
@@ -149,7 +149,7 @@ def get_input_haplotagged_bam(wildcards, config, *, default_path="snv_indels/wha
     dictionary to map phasers to their path prefixes.
 
     Args:
-        wildcards (snakemake.io.Wildcards): Wildcards object containing sample and type information.
+        wildcards (snakemake.io.container.Wildcards): Wildcards object containing sample and type information.
         config (dict): Configuration dictionary with possible keys:
             - phaser (str): Name of phasing tool used (e.g., 'whatshap', 'hiphase')
         set_type (str or None): Override the type from wildcards. Must be None, 'N', 'T', or 'R'.

--- a/hydra_genetics/utils/samples.py
+++ b/hydra_genetics/utils/samples.py
@@ -2,7 +2,7 @@
 
 import pandas
 
-from snakemake.io.container import Wildcards
+from snakemake.iocontainers import Wildcards
 
 
 def get_sample(samples: pandas.DataFrame, wildcards: Wildcards) -> pandas.Series:

--- a/hydra_genetics/utils/samples.py
+++ b/hydra_genetics/utils/samples.py
@@ -2,10 +2,11 @@
 
 import typing
 import pandas
-import snakemake
+
+from snakemake.io.container import Wildcards
 
 
-def get_sample(samples: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> pandas.Series:
+def get_sample(samples: pandas.DataFrame, wildcards: Wildcards) -> pandas.Series:
     """
     function used to extract one sample(row) from sample.tsv
     Args:

--- a/hydra_genetics/utils/samples.py
+++ b/hydra_genetics/utils/samples.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 
-import typing
 import pandas
 
 from snakemake.io.container import Wildcards
@@ -22,7 +21,7 @@ def get_sample(samples: pandas.DataFrame, wildcards: Wildcards) -> pandas.Series
     return samples.loc[(wildcards.sample)].dropna()
 
 
-def get_samples(samples: pandas.DataFrame) -> typing.List[str]:
+def get_samples(samples: pandas.DataFrame) -> list[str]:
     """
     function used to extract all sample found in samples.tsv
     Args:

--- a/hydra_genetics/utils/software_versions.py
+++ b/hydra_genetics/utils/software_versions.py
@@ -53,21 +53,10 @@ def get_container_prefix(workflow):
     """
     Function used to fetch singularity cache location
     """
-
-    if hasattr(workflow, "use_singularity"):
-        # Fetch singularity prefix for snakemake version with version less
-        # then 8
-        if hasattr(workflow, "singularity_prefix"):
-            return workflow.singularity_prefix
-        else:
-            return ".snakemake/singularity"
-    elif hasattr(workflow, "deployment_settings"):
-        # Fetch singularity prefix for snakemake version with equal to 8.0 or newer
-        if workflow.deployment_settings.apptainer_prefix is None:
-            return ".snakemake/singularity"
-        else:
-            return workflow.deployment_settings.apptainer_prefix
-    return None
+    if workflow.deployment_settings.apptainer_prefix is None:
+        return ".snakemake/singularity"
+    else:
+        return workflow.deployment_settings.apptainer_prefix
 
 
 def get_software_version_from_labels(image_path):
@@ -152,19 +141,11 @@ def use_container(workflow):
     """
     Function used to check if containers are used,
     """
-    if hasattr(workflow, "use_singularity"):
-        # For snakemake with version less then 8
-        return True
-    elif hasattr(workflow, "deployment_settings") and workflow.deployment_settings.deployment_method:
-        # For snakemake with version 8 or newer
-        from snakemake.settings import DeploymentMethod
+    from snakemake.settings.types import DeploymentMethod
 
-        if DeploymentMethod.APPTAINER in workflow.deployment_settings.deployment_method:
-            return True
-        else:
-            return False
-    else:
-        return False
+    if workflow.deployment_settings.deployment_method:
+        return DeploymentMethod.APPTAINER in workflow.deployment_settings.deployment_method
+    return False
 
 
 def add_software_version_to_config(config, workflow, fail_missing_versions=True):

--- a/hydra_genetics/utils/units.py
+++ b/hydra_genetics/utils/units.py
@@ -3,7 +3,7 @@
 import pandas
 import warnings
 
-from snakemake.io.container import Wildcards
+from snakemake.iocontainers import Wildcards
 
 
 def get_unit(units: pandas.DataFrame, wildcards: Wildcards) -> pandas.Series:

--- a/hydra_genetics/utils/units.py
+++ b/hydra_genetics/utils/units.py
@@ -1,11 +1,12 @@
 # coding: utf-8
 
 import pandas
-import snakemake
 import warnings
 
+from snakemake.io.container import Wildcards
 
-def get_unit(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> pandas.Series:
+
+def get_unit(units: pandas.DataFrame, wildcards: Wildcards) -> pandas.Series:
     """
     function used to extract one unit(row) from units.tsv
     Args:
@@ -22,7 +23,7 @@ def get_unit(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> pand
     return unit
 
 
-def get_fastq_file(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards, read_pair: str = "fastq1") -> str:
+def get_fastq_file(units: pandas.DataFrame, wildcards: Wildcards, read_pair: str = "fastq1") -> str:
     """
     function used to extract path for one unit(row) from units.tsv
     Args:
@@ -42,7 +43,7 @@ def get_fastq_file(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards, r
     return unit[read_pair]
 
 
-def get_fastq_adapter(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> str:
+def get_fastq_adapter(units: pandas.DataFrame, wildcards: Wildcards) -> str:
     """
     function used to extract adapters for one unit(row) from units.tsv
     Args:
@@ -59,7 +60,7 @@ def get_fastq_adapter(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards
     return unit["adapter"]
 
 
-def get_unit_barcodes(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> str:
+def get_unit_barcodes(units: pandas.DataFrame, wildcards: Wildcards) -> str:
     """
     function used to extract barcode for one unit(row) from units.tsv
     Args:
@@ -79,7 +80,7 @@ def get_unit_barcodes(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards
     ].itertuples()])
 
 
-def get_unit_machine(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> str:
+def get_unit_machine(units: pandas.DataFrame, wildcards: Wildcards) -> str:
     """
     function used to extract machine for one unit(row) from units.tsv
     Args:
@@ -96,7 +97,7 @@ def get_unit_machine(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards)
     return unit["machine"]
 
 
-def get_unit_platform(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> str:
+def get_unit_platform(units: pandas.DataFrame, wildcards: Wildcards) -> str:
     """
     function used to extract platform for one unit(row) from units.tsv
     Args:
@@ -113,7 +114,7 @@ def get_unit_platform(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards
     return unit["platform"]
 
 
-def get_unit_flowcell(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> str:
+def get_unit_flowcell(units: pandas.DataFrame, wildcards: Wildcards) -> str:
     """
     function used to extract flowcell for one unit(row) from units.tsv
     Args:
@@ -130,7 +131,7 @@ def get_unit_flowcell(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards
     return unit["flowcell"]
 
 
-def get_units(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards, type: str = None) -> pandas.DataFrame:
+def get_units(units: pandas.DataFrame, wildcards: Wildcards, type: str = None) -> pandas.DataFrame:
     """
     function used to extract one or more units from units.tsv
     Args:
@@ -156,7 +157,7 @@ def get_units(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards, type: 
     return [file for file in files.itertuples()]
 
 
-def get_fastq_files(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards, type: str = None):
+def get_fastq_files(units: pandas.DataFrame, wildcards: Wildcards, type: str = None):
     """
     function used to extract all fastq files for a sample with a sepecific type
     Args:
@@ -174,7 +175,7 @@ def get_fastq_files(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards, 
     return [getattr(file, wildcards.read) for file in get_units(units, wildcards, type)]
 
 
-def get_platforms(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards) -> set:
+def get_platforms(units: pandas.DataFrame, wildcards: Wildcards) -> set:
     """
     function used to extract all uniq platform values for a sample and type combination found in units.tsv
     Args:
@@ -206,7 +207,7 @@ def get_unit_types(units: pandas.DataFrame, sample: str) -> set:
     return set([u.type for u in units.loc[(sample,)].itertuples()])
 
 
-def get_units_per_flowcell(units: pandas.DataFrame, wildcards: snakemake.io.Wildcards):
+def get_units_per_flowcell(units: pandas.DataFrame, wildcards: Wildcards):
     """
     function used to extract all sample and type combinations for one sequencing flowcell
     Args:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,6 @@ nav:
 
 theme: readthedocs
 extra_css: [extra.css]
-theme: readthedocs
 extra_css: [extra.css]
 markdown_extensions:
   - abbr
@@ -40,6 +39,3 @@ markdown_extensions:
       url_download: "True"
   - mdx_spanner
   - admonition
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "click>=8,<9",
     "jinja2>=3.1.2",
     "rich>=13.0",
-    "snakemake>=9,<10",
+    "snakemake>=9.18.1,<10",
     "pysam",
     "gitpython",
     "pyaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "GPL-3"}
 authors = [
     {name = "Patrik Smeds", email = "patrik.smeds@scilifelab.uu.se"},
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 keywords = [
     "hydra-genetics",
     "snakemake",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "GPL-3"}
 authors = [
     {name = "Patrik Smeds", email = "patrik.smeds@scilifelab.uu.se"},
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 keywords = [
     "hydra-genetics",
     "snakemake",
@@ -25,11 +25,11 @@ keywords = [
     "next generation sequencing",
 ]
 dependencies = [
-    "pandas>=1.3.1",
+    "pandas>=2.0",
     "click>=8,<9",
-    "jinja2==3.0.1",
-    "rich==10.9.0",
-    "snakemake",
+    "jinja2>=3.1.2",
+    "rich>=13.0",
+    "snakemake>=9,<10",
     "pysam",
     "gitpython",
     "pyaml",

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,11 +1,11 @@
 click>=8,<9
 packaging
 gitpython
-jinja2==3.0.1
-pandas>=1.3.1
+jinja2>=3.1.2
+pandas>=2.0
 pyaml
 pycodestyle
 pysam
 pytest
-rich==10.9.0
-snakemake==7.13.0
+rich>=13.0
+snakemake>=9,<10

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -38,13 +38,30 @@ class TestResourcesUtils(unittest.TestCase):
     def test_variable_replacement(self):
         with open("tests/utils/files/config_variable_replacement.yaml") as f:
             config = yaml.load(f, Loader=yaml.loader.SafeLoader)
-        print(config)
         self.assertEqual(config,
                          {'PROJECT': 'MY variable', 'bwa_mem': {'extra': 'some settings {{PROJECT}}'}})
 
         from hydra_genetics.utils.misc import replace_dict_variables
         self.assertEqual(replace_dict_variables(config),
                          {'PROJECT': 'MY variable', 'bwa_mem': {'extra': 'some settings MY variable'}})
+
+    def test_variable_replacement_in_list(self):
+        from hydra_genetics.utils.misc import replace_dict_variables
+        config = {'VAR': 'hello', 'items': ['{{VAR}} world', 'no substitution']}
+        result = replace_dict_variables(config)
+        self.assertEqual(result['items'], ['hello world', 'no substitution'])
+
+    def test_variable_replacement_multiple_vars_in_string(self):
+        from hydra_genetics.utils.misc import replace_dict_variables
+        config = {'A': 'foo', 'B': 'bar', 'tool': {'extra': '{{A}}_{{B}}'}}
+        result = replace_dict_variables(config)
+        self.assertEqual(result['tool']['extra'], 'foo_bar')
+
+    def test_variable_replacement_undefined_variable_raises(self):
+        from hydra_genetics.utils.misc import replace_dict_variables
+        config = {'tool': {'extra': '{{UNDEFINED}}'}}
+        with self.assertRaises(KeyError):
+            replace_dict_variables(config)
 
 
 class TestGetInputAlignedBam(unittest.TestCase):
@@ -227,3 +244,27 @@ class TestGetInputHaplotaggedBam(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             get_input_haplotagged_bam(wildcards, config, set_type="X")
         self.assertIn("set_type must be None, 'N', 'T', or 'R'", str(context.exception))
+
+    def test_hiphase_phaser(self):
+        """Test hiphase phaser uses PHASED_BAM_PATHS lookup"""
+        wildcards = types.SimpleNamespace(sample="S18", type="T")
+        config = {"phaser": "hiphase"}
+        bam, bai = get_input_haplotagged_bam(wildcards, config)
+        self.assertEqual(bam, "snv_indels/hiphase/S18_T.haplotagged.bam")
+        self.assertEqual(bai, "snv_indels/hiphase/S18_T.haplotagged.bam.bai")
+
+    def test_unknown_phaser_fallback(self):
+        """Test unknown phaser falls back to snv_indels/{phaser}"""
+        wildcards = types.SimpleNamespace(sample="S19", type="N")
+        config = {"phaser": "custom_phaser"}
+        bam, bai = get_input_haplotagged_bam(wildcards, config)
+        self.assertEqual(bam, "snv_indels/custom_phaser/S19_N.haplotagged.bam")
+        self.assertEqual(bai, "snv_indels/custom_phaser/S19_N.haplotagged.bam.bai")
+
+    def test_explicit_phaser_none_uses_default(self):
+        """Test explicit phaser=None uses default_path"""
+        wildcards = types.SimpleNamespace(sample="S20", type="T")
+        config = {"phaser": None}
+        bam, bai = get_input_haplotagged_bam(wildcards, config)
+        self.assertEqual(bam, "snv_indels/whatshap_haplotag/S20_T.haplotagged.bam")
+        self.assertEqual(bai, "snv_indels/whatshap_haplotag/S20_T.haplotagged.bam.bai")

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -3,7 +3,6 @@
 import unittest
 import yaml
 import types
-from snakemake.sourcecache import WorkflowError
 from hydra_genetics.utils.misc import get_input_aligned_bam, get_input_haplotagged_bam
 
 

--- a/tests/utils/test_samples.py
+++ b/tests/utils/test_samples.py
@@ -2,7 +2,7 @@
 
 import unittest
 import pandas as pandas
-from snakemake.io import Wildcards
+from snakemake.io.container import Wildcards
 
 
 class TestSampleUtils(unittest.TestCase):

--- a/tests/utils/test_samples.py
+++ b/tests/utils/test_samples.py
@@ -2,7 +2,7 @@
 
 import unittest
 import pandas as pandas
-from snakemake.io.container import Wildcards
+from snakemake.iocontainers import Wildcards
 
 
 class TestSampleUtils(unittest.TestCase):

--- a/tests/utils/test_software_versions.py
+++ b/tests/utils/test_software_versions.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+
+import unittest
+from unittest.mock import MagicMock
+
+from snakemake.settings.types import DeploymentMethod
+
+from hydra_genetics.utils.software_versions import get_container_prefix, get_image_path, use_container
+
+
+def _make_workflow(apptainer_prefix=None, deployment_method=None):
+    """Helper to build a mock snakemake workflow with snakemake 9 deployment_settings."""
+    workflow = MagicMock()
+    workflow.deployment_settings.apptainer_prefix = apptainer_prefix
+    workflow.deployment_settings.deployment_method = deployment_method if deployment_method is not None else set()
+    return workflow
+
+
+class TestGetContainerPrefix(unittest.TestCase):
+    def test_returns_default_when_prefix_is_none(self):
+        workflow = _make_workflow(apptainer_prefix=None)
+        self.assertEqual(get_container_prefix(workflow), ".snakemake/singularity")
+
+    def test_returns_configured_prefix(self):
+        workflow = _make_workflow(apptainer_prefix="/custom/apptainer/cache")
+        self.assertEqual(get_container_prefix(workflow), "/custom/apptainer/cache")
+
+
+class TestUseContainer(unittest.TestCase):
+    def test_returns_true_when_apptainer_in_deployment_method(self):
+        workflow = _make_workflow(deployment_method={DeploymentMethod.APPTAINER})
+        self.assertTrue(use_container(workflow))
+
+    def test_returns_false_when_apptainer_not_in_deployment_method(self):
+        workflow = _make_workflow(deployment_method=set())
+        self.assertFalse(use_container(workflow))
+
+    def test_returns_false_when_deployment_method_is_empty(self):
+        workflow = _make_workflow(deployment_method=set())
+        self.assertFalse(use_container(workflow))
+
+
+class TestGetImagePath(unittest.TestCase):
+    def test_local_file_returned_unchanged(self):
+        path = "/data/images/mycontainer.sif"
+        self.assertEqual(get_image_path(path, "/prefix"), path)
+
+    def test_docker_url_returns_md5_simg_path(self):
+        container = "docker://hydragenetics/bcbio-vc:0.2.6"
+        prefix = ".snakemake/singularity"
+        result = get_image_path(container, prefix)
+        self.assertTrue(result.startswith(prefix + "/"))
+        self.assertTrue(result.endswith(".simg"))
+
+    def test_same_docker_url_produces_same_path(self):
+        container = "docker://hydragenetics/bcbio-vc:0.2.6"
+        prefix = ".snakemake/singularity"
+        self.assertEqual(get_image_path(container, prefix), get_image_path(container, prefix))
+
+    def test_different_docker_urls_produce_different_paths(self):
+        prefix = ".snakemake/singularity"
+        path1 = get_image_path("docker://hydragenetics/image1:1.0", prefix)
+        path2 = get_image_path("docker://hydragenetics/image2:1.0", prefix)
+        self.assertNotEqual(path1, path2)

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 import pandas
 from pandas.testing import assert_series_equal, assert_frame_equal
-from snakemake.io.container import Wildcards
+from snakemake.iocontainers import Wildcards
 
 
 class TestUnitUtils(unittest.TestCase):

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 import pandas
 from pandas.testing import assert_series_equal, assert_frame_equal
-from snakemake.io import Wildcards
+from snakemake.io.container import Wildcards
 
 
 class TestUnitUtils(unittest.TestCase):


### PR DESCRIPTION
Raise minimum supported Python version from 3.8 to 3.12 and pin snakemake to >=9,<10. Update all snakemake internal API references that changed between snakemake 7 and 9.

BREAKING CHANGE: drops support for Python <3.12 and snakemake <9

Snakemake API changes:
 - snakemake.io.Wildcards moved to snakemake.io.container.Wildcards
 - snakemake.settings.DeploymentMethod moved to snakemake.settings.types
 - remove snakemake 7 compatibility branches from get_container_prefix() and use_container() in software_versions.py

Dependency updates:
 - jinja2==3.0.1 -> >=3.1.2 (Python 3.12 compatibility)
 - rich==10.9.0 -> >=13.0 (Python 3.12 compatibility)
 - pandas>=1.3.1 -> >=2.0 (Python 3.12 compatibility)
 - snakemake unpinned/==7.13.0 -> >=9,<10

CI: update all workflows from Python 3.8 to 3.12, actions/checkout and actions/setup-python to latest versions (v4/v5)

Tests: add test_software_versions.py covering get_container_prefix(), use_container(), and get_image_path() against the snakemake 9 API

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python requirement from 3.8 to 3.12
  * Updated CI/CD workflows to use latest GitHub Actions versions
  * Modernized core dependencies (pandas, jinja2, rich, snakemake) to current versions

* **Tests**
  * Added comprehensive test coverage for container and deployment utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->