### PR TITLE
fix: Add exit on failed retrieval in references.py

### DIFF
--- a/hydra_genetics/commands/references.py
+++ b/hydra_genetics/commands/references.py
@@ -222,6 +222,7 @@ def download(validation_file, output_dir, force):
     if len(failed_list) > 0:
         logging.error(f"Failed to retrieve {len(failed_list)}")
         logging.error(f"Failed: {', '.join(failed_list)}")
+        exit(1)
 
     if len(skipped_list) > 0:
         logging.info(f"Skipped {len(skipped_list)} since checksum didn't change")


### PR DESCRIPTION
The validate command has an exit when a fail is detected. The download command should also have the same behavior.


### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for failed downloads—the download command now properly signals when items fail to download.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hydra-genetics/hydra-genetics/pull/442)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->